### PR TITLE
Makefile: Improve `deploy` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 YAML2JSON = ( python -c 'import sys, yaml, json; json.dump(yaml.load(sys.stdin), sys.stdout, indent=4)' 2>/dev/null || ruby -ryaml -rjson -e 'puts JSON.pretty_generate(YAML.load(ARGF))' )
-MARATHON_CURL = curl -s -X PUT -H "Content-type: application/json" -d @-
+MARATHON_CURL = curl --silent --show-error -X PUT -H "Content-type: application/json" -d @-
 
 DOCKER_IP ?= 127.0.0.1
 export DOCKER_IP
 
 .PHONY: run
 deploy:
-	$(YAML2JSON) < apps/$(APP).yaml | $(MARATHON_CURL) http://dev:8080/v2/groups | jq .
+	$(YAML2JSON) < apps/$(APP).yaml | $(MARATHON_CURL) http://$(DOCKER_IP):8080/v2/groups | jq .
 
 .PHONY: run
 run:


### PR DESCRIPTION
- Use `--show-error` option to `curl` so that we're silent about normal
  operation, but still show errors that occur.

- Replace `dev` with `$(DOCKER_IP)` so that it works without doing DNS
  or `/etc/hosts` tricks.

```
$ make APP=example deploy
( python -c 'import sys, yaml, json; json.dump(yaml.load(sys.stdin), sys.stdout, indent=4)' 2>/dev/null || ruby -ryaml -rjson -e 'puts JSON.pretty_generate(YAML.load(ARGF))' ) < apps/example.yaml | curl --silent --show-error -X PUT -H "Content-type: application/json" -d @- http://192.168.99.100:8080/v2/groups | jq .
{
  "version": "2017-01-11T17:50:18.785Z",
  "deploymentId": "a6f63ae1-3037-4ab3-a35f-12d5dfcf82d3"
}
```

or if I stop `marathon` and do this, note that an error is reported (which was
not true before):

```
$ make APP=example deploy
( python -c 'import sys, yaml, json; json.dump(yaml.load(sys.stdin), sys.stdout, indent=4)' 2>/dev/null || ruby -ryaml -rjson -e 'puts JSON.pretty_generate(YAML.load(ARGF))' ) < apps/example.yaml | curl --silent --show-error -X PUT -H "Content-type: application/json" -d @- http://192.168.99.100:8080/v2/groups | jq .
curl: (7) Failed to connect to 192.168.99.100 port 8080: Connection refused
```