### PR TITLE
Add MESOS_WORK_DIR for slave-two

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,7 @@ services:
   #     MESOS_RESOURCES: ports(*):[12000-12999]
   #     MESOS_HOSTNAME: ${DOCKER_IP}
   #     LIBPROCESS_IP: ${DOCKER_IP}
+  #     MESOS_WORK_DIR: /tmp/mesos
   #   volumes:
   #     - /sys/fs/cgroup:/sys/fs/cgroup
   #     - /usr/local/bin/docker:/usr/bin/docker


### PR DESCRIPTION
Otherwise, if I uncomment `slave-two` and try to start it, it fails with:

```
$ docker-compose logs slave-two
Attaching to mesoscompose_slave-two_1
slave-two_1  | Flag 'work_dir' is required, but it was not provided
slave-two_1  |
slave-two_1  | Usage: mesos-slave [options]
```