### PR TITLE
Add mesos-compose launcher script

### DIFF
--- a/mesos-compose
+++ b/mesos-compose
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+cd "$DIR"
+echo "mesos-compose running from $DIR"
+echo
+[ -f .envrc ] && source .envrc
+
+MASTER_URL="http://$DOCKER_IP:5050"
+SLAVE1_URL="http://$DOCKER_IP:5051"
+SLAVE1_STATE_URL="$SLAVE1_URL/state"
+SLAVE2_URL="http://$DOCKER_IP:5052"
+SLAVE2_STATE_URL="$SLAVE2_URL/state"
+MARATHON_URL="http://$DOCKER_IP:8080"
+CHRONOS_URL="http://$DOCKER_IP:8888"
+
+if [ "$1" = "open" ]; then
+    case "$2" in
+        master)
+            exec python -c "import webbrowser; webbrowser.open('$MASTER_URL')"
+            ;;
+        slave|slave1)
+            exec python -c "import webbrowser; webbrowser.open('$SLAVE1_STATE_URL')"
+            ;;
+        slave2)
+            exec python -c "import webbrowser; webbrowser.open('$SLAVE2_STATE_URL')"
+            ;;
+        marathon)
+            exec python -c "import webbrowser; webbrowser.open('$MARATHON_URL')"
+            ;;
+        chronos)
+            exec python -c "import webbrowser; webbrowser.open('$CHRONOS_URL')"
+            ;;
+        *)
+            echo "open: Unknown app: \"$2\"; choices are: master, slave1, marathon, chronos" 1>&2
+            exit 1
+            ;;
+    esac
+elif [ "$1" = "get" ]; then
+    ENDPOINT="${3:-ping}"
+
+    case "$2" in
+        master)
+            ENDPOINT="${3:-health}"
+            exec http ${MASTER_URL}/${ENDPOINT}
+            ;;
+        slave|slave1)
+            ENDPOINT="${3:-health}"
+            exec http ${SLAVE1_URL}/${ENDPOINT}
+            ;;
+        slave2)
+            ENDPOINT="${3:-health}"
+            exec http ${SLAVE2_URL}/${ENDPOINT}
+            ;;
+        marathon)
+            exec http ${MARATHON_URL}/${ENDPOINT}
+            ;;
+        chronos)
+            exec http ${CHRONOS_URL}/${ENDPOINT}
+            ;;
+        *)
+            echo "open: Unknown app: \"$2\"; choices are: master, slave1, marathon, chronos" 1>&2
+            exit 1
+            ;;
+    esac
+fi
+
+docker-compose "$@"


### PR DESCRIPTION
This is a little script that I have been experimenting with. I've mostly been using this instead of flotilla and it works pretty well for me. And AFAICT, flotilla isn't open-source, so this might be a good addition for folks using `mesos-compose` who don't have flotilla.

Examples of use:

```
$ mesos-compose ps
mesos-compose running from /Users/abramowi/Documents/Code/chr0n1x/mesos-compose

          Name                        Command               State    Ports
--------------------------------------------------------------------------
mesoscompose_marathon_1    ./bin/start                      Up
mesoscompose_master_1      mesos-master --registry=in ...   Exit 1
mesoscompose_slave-one_1   mesos-slave                      Up
mesoscompose_zk_1          /run.sh                          Up

abramowi at abramowi-osx in ~/dev/git-repos/mesos-compose (script●)
$ mesos-compose get master
mesos-compose running from /Users/abramowi/Documents/Code/chr0n1x/mesos-compose

http: error: ConnectionError: HTTPConnectionPool(host='192.168.190.128', port=5050): Max retries exceeded with url: /health (Caused by NewConnectionError('<requests.packages.urllib3.connection.HTTPConnection object at 0x105667d10>: Failed to establish a new connection: [Errno 61] Connection refused',)) while doing GET request to URL: http://192.168.190.128:5050/health

$ mesos-compose up -d
mesos-compose running from /Users/abramowi/Documents/Code/chr0n1x/mesos-compose

mesoscompose_zk_1 is up-to-date
Starting mesoscompose_master_1
mesoscompose_slave-one_1 is up-to-date
mesoscompose_marathon_1 is up-to-date

$ mesos-compose get master
mesos-compose running from /Users/abramowi/Documents/Code/chr0n1x/mesos-compose

HTTP/1.1 200 OK
Content-Length: 0
Date: Wed, 25 Jan 2017 17:34:44 GMT
```